### PR TITLE
Feature/Joint Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 # Godot 4 Verlet Rope (.NET)
-It is an implementation of [Verlet Intergration](https://en.wikipedia.org/wiki/Verlet_integration) for physics ropes on Godot 4.4 .NET similar to the ones seen in `Half-Life 2` or generally in `Source` engine.
+It is an implementation of [Verlet Integration](https://en.wikipedia.org/wiki/Verlet_integration) for physics ropes on Godot 4.4 .NET similar to the ones seen in `Half-Life 2` or generally in `Source` engine.
 
 This addon allows creation of dynamic and physics-based ropes, specifically offering following specialized nodes to fit different needs:
 * **`VerletRopeSimulated`**: Customizable and performant node for visual ropes that react to wind, gravity, and collisions with smooth, realistic behavior.
@@ -35,13 +35,13 @@ This addon allows creation of dynamic and physics-based ropes, specifically offe
 ## Features
 1. **Generation of flat-plane rope meshes** using tessellation with Catmull-Rom splines.
 2. **Two variants of rope simulation**: fully verlet-based (optionally affected by other bodies) and built-in physics-based (both affects and is affected by other bodies).
-3. **Intergrated joint nodes** allowing to connect ropes to other nodes and physical bodies, constraining their movement.
-4. **Many adjustable parameters**: particle & segment counts; lengths & widths; custom simulation rates; wind & gravity forces; customizable damping; customizable visuals; and other fine-tunning settings specific to each rope variant.
+3. **Integrated joint nodes** allowing to connect ropes to other nodes and physical bodies, constraining their movement.
+4. **Many adjustable parameters**: particle & segment counts; lengths & widths; custom simulation rates; wind & gravity forces; customizable damping; customizable visuals; and other fine-tuning settings specific to each rope variant.
 5. **`VisibleOnScreenNotifier3D` optional support** (integrated and automatic) for performance improvements when required.
-6. **Simualted advanced performance-friendly slide collisions** for `VerletRopeSimulated` with static mode `O(n)` and dynamic mode `O(n*m)` raycasts complexity (`n` - rope particles, `m` - affected dynamic bodies).
+6. **Simulated advanced performance-friendly slide collisions** for `VerletRopeSimulated` with static mode `O(n)` and dynamic mode `O(n*m)` raycasts complexity (`n` - rope particles, `m` - affected dynamic bodies).
 7. **Editor-specific tooling** to make ropes configuration easier.
    * Different `[Tool]` buttons for quick joint creation, rope resets, structure copying and quick configuration presets;
-   * Internal meta-stamping for ropes duplications/copypaste support;
+   * Internal meta-stamping for ropes duplication/copy-paste support;
    * Custom editor-collisions for precise rope click-selectors.
 
 ## Installation
@@ -55,8 +55,8 @@ Ensure you have **Godot 4.4.1+ .NET** and the **.NET 8 SDK** installed.
 > Checkout full installation guide if you need additional details or demo steps at [this wiki page](https://github.com/Tshmofen/verlet-rope-4/wiki/Guide-%E2%80%90-Installation).
 
 ## Quick Start
-The followind nodes are being added to the `Create Child Node` menu, try them out yourself and see their corresponding wiki pages by the following links, you can find specific properties descriptions and recommendations there:
-* **[`VerletRopeSimulated`](https://github.com/Tshmofen/verlet-rope-4/wiki/Documentation-%E2%80%90-VerletRopeSimulated)** -> `Node3D` - First of the two rope nodes, provides access to fully verlet-simualted rope with the most settings available.
+The following nodes are being added to the `Create Child Node` menu, try them out yourself and see their corresponding wiki pages by the following links, you can find specific properties descriptions and recommendations there:
+* **[`VerletRopeSimulated`](https://github.com/Tshmofen/verlet-rope-4/wiki/Documentation-%E2%80%90-VerletRopeSimulated)** -> `Node3D` - First of the two rope nodes, provides access to fully verlet-simulated rope with the most settings available.
   * **[`VerletJointSimulated`](https://github.com/Tshmofen/verlet-rope-4/wiki/Documentation-%E2%80%90-VerletJointSimulated)** -> `Node` - Corresponding simulated joint utility node.
 * **[`VerletRopeRigidBody`](https://github.com/Tshmofen/verlet-rope-4/wiki/Documentation-%E2%80%90-VerletRopeRigidBody)** -> `Node3D` - Second rope node, provides access to rigid-bodies-based rope, that allows it to properly interact with physics. 
   * **[`VerletJointRigid`](https://github.com/Tshmofen/verlet-rope-4/wiki/Documentation-%E2%80%90-VerletJointRigid)** -> `Node` - Corresponding rigid joint utility node.

--- a/addons/verlet_rope_4/Physics/BaseVerletRopePhysical.cs
+++ b/addons/verlet_rope_4/Physics/BaseVerletRopePhysical.cs
@@ -18,12 +18,14 @@ public abstract partial class BaseVerletRopePhysical : Node3D, ISerializationLis
     
     protected RopeParticleData ParticleData;
     protected VerletRopeMesh RopeMesh => _ropeMesh ??= this.FindOrCreateChild<VerletRopeMesh>();
-
-    protected PhysicsBody3D StartBody { get; set; }
-    protected Node3D StartNode { get; set; }
-
-    protected PhysicsBody3D EndBody { get; set; }
-    protected Node3D EndNode { get; set; }
+    
+    protected Node3D PreviousStart { get; private set; }
+    protected PhysicsBody3D StartBody { get; private set; }
+    protected Node3D StartNode { get; private set; }
+    
+    protected Node3D PreviousEnd { get; private set; }
+    protected PhysicsBody3D EndBody { get; private set; }
+    protected Node3D EndNode { get; private set; }
     
     // Properties have the same default values as on `RopeMesh`
     /// <inheritdoc cref="VerletRopeMesh.RopeLength"/>
@@ -41,7 +43,7 @@ public abstract partial class BaseVerletRopePhysical : Node3D, ISerializationLis
     [Export] public Material MaterialOverride { get; set; }
     
     /// <summary> Resets the rope and all corresponding properties, have to be called after any property changes. It is being called when you press `Reset Rope` quick button. </summary>
-    public virtual void CreateRope()
+    public virtual void CreateRope(bool forceReset = true)
     {
         RopeMesh.RopeLength = RopeLength;
         RopeMesh.RopeWidth = RopeWidth;
@@ -59,8 +61,11 @@ public abstract partial class BaseVerletRopePhysical : Node3D, ISerializationLis
 
     public void SetAttachments(PhysicsBody3D startBody, Node3D startLocation, PhysicsBody3D endBody, Node3D endLocation)
     {
+        PreviousStart = StartNode ?? StartBody;
         StartBody = startBody;
         StartNode = startLocation ?? startBody;
+        
+        PreviousEnd = EndNode ?? EndBody ;
         EndBody = endBody;
         EndNode = endLocation ?? endBody;
     }
@@ -153,7 +158,7 @@ public abstract partial class BaseVerletRopePhysical : Node3D, ISerializationLis
 
     public void OnAfterDeserialize()
     {
-        CallDeferred(MethodName.CreateRope);
+        CallDeferred(MethodName.CreateRope, true);
     }
 
     #endregion

--- a/addons/verlet_rope_4/Physics/Joints/BaseVerletJoint.cs
+++ b/addons/verlet_rope_4/Physics/Joints/BaseVerletJoint.cs
@@ -32,7 +32,7 @@ public abstract partial class BaseVerletJoint : Node, ISerializationListener
     {
         if (StartBody == null && StartCustomLocation == null && EndBody == null && EndCustomLocation == null)
         {
-            return ["No custom bodies specified, joint is doing nothing - consider resetting or removing it."];
+            return ["No custom connection points specified, joint is doing nothing - consider resetting or removing it."];
         }
 
         return [];

--- a/addons/verlet_rope_4/Physics/Joints/DistanceForceJoint.cs
+++ b/addons/verlet_rope_4/Physics/Joints/DistanceForceJoint.cs
@@ -47,15 +47,20 @@ public partial class DistanceForceJoint : Node, IVerletExported
 
     public override void _PhysicsProcess(double delta)
     {
-        if (MaxDistance == 0 || BodyA == null || BodyB == null)
+        if (MaxDistance == 0)
         {
             return;
         } 
 
-        var a = CustomLocationA?.GlobalPosition ?? BodyA.GlobalPosition;
-        var b = CustomLocationB?.GlobalPosition ?? BodyB.GlobalPosition;
+        var a = CustomLocationA?.GlobalPosition ?? BodyA?.GlobalPosition;
+        var b = CustomLocationB?.GlobalPosition ?? BodyB?.GlobalPosition;
 
-        var connectionDirection = b - a;
+        if (a == null || b == null)
+        {
+            return;
+        }
+
+        var connectionDirection = (b - a).Value;
         var connectionDistance = connectionDirection.Length();
 
         if (connectionDistance < MaxDistance)

--- a/addons/verlet_rope_4/Physics/Joints/VerletJointRigid.cs
+++ b/addons/verlet_rope_4/Physics/Joints/VerletJointRigid.cs
@@ -49,6 +49,6 @@ public partial class VerletJointRigid : BaseVerletJoint, IVerletExported
         base.ResetJoint();
         VerletRope ??= GetParent() as VerletRopeRigid;
         VerletRope?.SetAttachments(StartBody, StartCustomLocation, EndBody, EndCustomLocation);
-        VerletRope?.CallDeferred(VerletRopeRigid.MethodName.CreateRope);
+        VerletRope?.CallDeferred(VerletRopeRigid.MethodName.CreateRope, true);
     }
 }

--- a/addons/verlet_rope_4/Physics/Joints/VerletJointSimulated.cs
+++ b/addons/verlet_rope_4/Physics/Joints/VerletJointSimulated.cs
@@ -104,7 +104,7 @@ public partial class VerletJointSimulated : BaseVerletJoint, IVerletExported
             VerletRope?.RegisterExceptionRid(StartBody.GetRid(), IgnoreStartBodyCollision);
         }
         
-        VerletRope?.CallDeferred(VerletRopeSimulated.MethodName.CreateRope);
+        VerletRope?.CallDeferred(VerletRopeSimulated.MethodName.CreateRope, true);
     }
 
     public override string[] _GetConfigurationWarnings()

--- a/addons/verlet_rope_4/Physics/Joints/VerletJointSimulated.cs
+++ b/addons/verlet_rope_4/Physics/Joints/VerletJointSimulated.cs
@@ -62,7 +62,7 @@ public partial class VerletJointSimulated : BaseVerletJoint, IVerletExported
 
     private void ConfigureDistanceJoint()
     {
-        if (JointMaxDistance == 0 || StartBody == null || EndBody == null)
+        if (JointMaxDistance == 0 || (StartBody == null && EndBody == null))
         {
             _joint?.Dispose();
             _joint = null;
@@ -77,6 +77,11 @@ public partial class VerletJointSimulated : BaseVerletJoint, IVerletExported
         _joint.CustomLocationB = EndCustomLocation;
         _joint.ForceEasing = JointForceEasing;
         _joint.MaxForce = JointMaxForce;
+
+        if (StartBody == null && StartCustomLocation == null)
+        {
+            _joint.CustomLocationA = VerletRope;
+        }
     }
 
     /// <inheritdoc cref="BaseVerletJoint.ResetJoint"/>
@@ -104,16 +109,24 @@ public partial class VerletJointSimulated : BaseVerletJoint, IVerletExported
 
     public override string[] _GetConfigurationWarnings()
     {
-        var baseWarnings = base._GetConfigurationWarnings();
+        var warnings = base._GetConfigurationWarnings().ToList();
 
-        if (JointMaxDistance > 0 && (StartBody is null || EndBody is null))
+        if (VerletRope == null)
         {
-            return baseWarnings
-                .Union([$"{nameof(JointMaxDistance)} is configured but either `{nameof(StartBody)}` or `{nameof(EndBody)}` is not accessible for physical connection."])
-                .ToArray();
+            warnings.Add("Joint will do nothing without an associated rope, please assign one."); 
         }
 
-        return baseWarnings;
+        if (JointMaxDistance > 0 && StartBody is null && EndBody is null)
+        {
+            warnings.Add($"{nameof(JointMaxDistance)} is configured but both `{nameof(StartBody)}` and `{nameof(EndBody)}` are not accessible for physical connection.");
+        }
+
+        if (JointMaxDistance > 0 && VerletRope?.IsDisabledWhenInvisible == true)
+        {
+            warnings.Add($"Rope has `{nameof(VerletRopeSimulated.IsDisabledWhenInvisible)}` enabled, if your joint is moving it might lead to rope not being drawn when it leaves the screen - consider disabling it.");
+        }
+
+        return warnings.ToArray();
     }
 
     #region Script Reload

--- a/addons/verlet_rope_4/Physics/Presets/VerletRopeSimulatedPreset.cs
+++ b/addons/verlet_rope_4/Physics/Presets/VerletRopeSimulatedPreset.cs
@@ -14,14 +14,14 @@ public static class VerletRopeSimulatedPreset
         undoRedo.AddDoProperty(verletRope, VerletRopeSimulated.PropertyName.WindNoiseMin, 0.05f);
         undoRedo.AddDoProperty(verletRope, VerletRopeSimulated.PropertyName.WindNoiseMax, 1.0f);
         undoRedo.AddDoProperty(verletRope, VerletRopeSimulated.PropertyName.WindNoise, new FastNoiseLite { Frequency = 0.03f });
-        undoRedo.AddDoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope);
+        undoRedo.AddDoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope, true);
         
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.ApplyWind, verletRope.ApplyWind);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.WindDirection, verletRope.WindDirection);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.WindNoiseMin, verletRope.WindNoiseMin);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.WindNoiseMax, verletRope.WindNoiseMax);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.WindNoise, verletRope.WindNoise);
-        undoRedo.AddUndoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope);
+        undoRedo.AddUndoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope, true);
     }
 
     public static void SetFloatingValues(VerletRopeSimulated verletRope, EditorUndoRedoManager undoRedo, int actionId)
@@ -30,13 +30,13 @@ public static class VerletRopeSimulatedPreset
         undoRedo.AddDoProperty(verletRope, VerletRopeSimulated.PropertyName.StiffnessIterations, 2);
         undoRedo.AddDoProperty(verletRope, VerletRopeSimulated.PropertyName.ApplyDamping, true);
         undoRedo.AddDoProperty(verletRope, VerletRopeSimulated.PropertyName.DampingFactor, 2000.0f);
-        undoRedo.AddDoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope);
+        undoRedo.AddDoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope, true);
         
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.Stiffness, verletRope.Stiffness);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.StiffnessIterations, verletRope.StiffnessIterations);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.ApplyDamping, verletRope.ApplyDamping);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.DampingFactor, verletRope.DampingFactor);
-        undoRedo.AddUndoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope);
+        undoRedo.AddUndoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope, true);
     }
 
     public static void SetBaseAllCollisionsValues(VerletRopeSimulated verletRope, EditorUndoRedoManager undoRedo, int actionId)
@@ -47,7 +47,7 @@ public static class VerletRopeSimulatedPreset
         undoRedo.AddDoProperty(verletRope, VerletRopeSimulated.PropertyName.IgnoreCollisionStretch, 5.0f);
         undoRedo.AddDoProperty(verletRope, VerletRopeSimulated.PropertyName.MaxDynamicCollisions, 4);
         undoRedo.AddDoProperty(verletRope, VerletRopeSimulated.PropertyName.DynamicCollisionTrackingMargin, 1.0f);
-        undoRedo.AddDoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope);
+        undoRedo.AddDoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope, true);
         
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.RopeCollisionType, (int) verletRope.RopeCollisionType);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.RopeCollisionBehavior, (int) verletRope.RopeCollisionBehavior);
@@ -55,7 +55,7 @@ public static class VerletRopeSimulatedPreset
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.IgnoreCollisionStretch, verletRope.IgnoreCollisionStretch);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.MaxDynamicCollisions, verletRope.MaxDynamicCollisions);
         undoRedo.AddUndoProperty(verletRope, VerletRopeSimulated.PropertyName.DynamicCollisionTrackingMargin, verletRope.DynamicCollisionTrackingMargin);
-        undoRedo.AddUndoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope);
+        undoRedo.AddUndoMethod(verletRope, VerletRopeSimulated.MethodName.CreateRope, true);
     }
 
     #endif

--- a/addons/verlet_rope_4/Physics/VerletRopeRigid.cs
+++ b/addons/verlet_rope_4/Physics/VerletRopeRigid.cs
@@ -215,6 +215,7 @@ public partial class VerletRopeRigid : BaseVerletRopePhysical, IVerletExported
     {
         base._Ready();
         CreateRope();
+        RopeMesh.UpdateRopeVisibility(ParticleData);
     }
 
     public override void _PhysicsProcess(double delta)
@@ -240,6 +241,7 @@ public partial class VerletRopeRigid : BaseVerletRopePhysical, IVerletExported
         }
 
         RopeMesh.DrawRopeParticles(ParticleData);
+        RopeMesh.UpdateRopeVisibility(ParticleData);
 
         #if TOOLS
         UpdateEditorCollision(ParticleData);

--- a/addons/verlet_rope_4/Physics/VerletRopeRigid.cs
+++ b/addons/verlet_rope_4/Physics/VerletRopeRigid.cs
@@ -18,7 +18,7 @@ public partial class VerletRopeRigid : BaseVerletRopePhysical, IVerletExported
     private List<RigidBody3D> _segmentBodies;
 
     #if TOOLS
-    [ExportToolButton("Reset Rope (Apply Changes)")] public Callable ResetRopeButton => Callable.From(CreateRope);
+    [ExportToolButton("Reset Rope (Apply Changes)")] public Callable ResetRopeButton => Callable.From(() => CreateRope());
     [ExportToolButton("Clone Rigid Bodies")] public Callable CloneBodiesButton => Callable.From(CloneRigidBodiesAction);
     [ExportToolButton("Add Rigid Joint")] public Callable AddJointButton => Callable.From(CreateJointAction);
     #endif
@@ -294,7 +294,7 @@ public partial class VerletRopeRigid : BaseVerletRopePhysical, IVerletExported
     }
     
     /// <inheritdoc cref="BaseVerletRopePhysical.CreateRope"/>
-    public override void CreateRope()
+    public override void CreateRope(bool forceReset = true)
     {
         DestroyRope();
 
@@ -304,7 +304,7 @@ public partial class VerletRopeRigid : BaseVerletRopePhysical, IVerletExported
             return;
         }
 
-        base.CreateRope();
+        base.CreateRope(forceReset);
         _segmentBodies = SpawnSegmentBodies(this);
         PinSegmentBodies(_segmentBodies);
         ParticleData = GenerateParticleData(_segmentBodies);

--- a/addons/verlet_rope_4/Physics/VerletRopeSimulated.cs
+++ b/addons/verlet_rope_4/Physics/VerletRopeSimulated.cs
@@ -482,6 +482,7 @@ public partial class VerletRopeSimulated : BaseVerletRopePhysical, IVerletExport
         };
 
         CreateRope();
+        RopeMesh.UpdateRopeVisibility(ParticleData);
     }
 
     public override void _PhysicsProcess(double delta)
@@ -534,6 +535,7 @@ public partial class VerletRopeSimulated : BaseVerletRopePhysical, IVerletExport
         VerletProcess(simulationDeltaF);
         ApplyConstraints(simulationDeltaF);
         RopeMesh.DrawRopeParticles(ParticleData);
+        RopeMesh.UpdateRopeVisibility(ParticleData);
 
         EmitSignalSimulationStep(_simulationDelta);
         _simulationDelta = 0;

--- a/addons/verlet_rope_4/Rendering/VerletRopeMesh.cs
+++ b/addons/verlet_rope_4/Rendering/VerletRopeMesh.cs
@@ -240,15 +240,30 @@ public partial class VerletRopeMesh : MeshInstance3D, IVerletExported
         ResetRopeRotation();
         DrawCurve(particles);
 
-        if (_visibleNotifier != null)
-        {
-            _visibleNotifier.Aabb = GetAabb();
-        }
-
         if (UseDebugParticles)
         {
             DrawRopeDebugParticles(particles);
         }
+    }
+
+    public void UpdateRopeVisibility(RopeParticleData particles)
+    {
+        if (_visibleNotifier == null || particles == null || particles.Count == 0)
+        {
+            return;
+        }
+
+        var minPosition =  new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+        var maxPosition = new Vector3(float.MinValue, float.MinValue, float.MinValue);
+
+        for (var i = 0; i < particles.Count; i++)
+        {
+            ref var particle = ref particles[i];
+            minPosition = minPosition.Min(particle.PositionCurrent);
+            maxPosition = maxPosition.Max(particle.PositionCurrent);
+        }
+
+        _visibleNotifier.Aabb = new Aabb(_visibleNotifier.ToLocal(minPosition), _visibleNotifier.ToLocal(maxPosition - minPosition)).Abs();
     }
 
     public override string[] _GetConfigurationWarnings()

--- a/addons/verlet_rope_4/plugin.cfg
+++ b/addons/verlet_rope_4/plugin.cfg
@@ -3,5 +3,5 @@
 name="Verlet Rope 4"
 description="Adds several rope-related nodes allowing creation of dynamic and physics-based rope interactions."
 author="tshmofen"
-version="2.0.0"
+version="2.0.1"
 script="VerletRopePlugin.cs"

--- a/demo/demo.tscn
+++ b/demo/demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=3 uid="uid://bota3ppynjsu1"]
+[gd_scene load_steps=28 format=3 uid="uid://bota3ppynjsu1"]
 
 [ext_resource type="Script" uid="uid://cmi6i20suro26" path="res://demo/scripts/RotatingCameraDemo.cs" id="1_tdg64"]
 [ext_resource type="PackedScene" uid="uid://cqnic6frw022r" path="res://demo/objects/ground.tscn" id="1_ykvhj"]
@@ -48,13 +48,16 @@ albedo_color = Color(0, 0.909527, 0.380237, 1)
 cull_mode = 2
 albedo_color = Color(0, 0.537301, 0.892989, 1)
 
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_nk31j"]
+albedo_color = Color(0.873917, 0.609853, 0, 1)
+
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_onu7k"]
 cull_mode = 2
 albedo_color = Color(0.789868, 0.610247, 0, 1)
 
 [sub_resource type="ImmediateMesh" id="ImmediateMesh_nk31j"]
 resource_local_to_scene = true
-metadata/verlet_rope_internal_stamp = 24438011675750
+metadata/verlet_rope_internal_stamp = 23819586715240
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_1rqa4"]
 albedo_color = Color(0.582917, 0, 0.0906055, 1)
@@ -67,7 +70,7 @@ albedo_color = Color(0.582917, 0, 0.0906055, 1)
 environment = SubResource("Environment_2p4hb")
 
 [node name="Camera3D" type="Camera3D" parent="Environment"]
-transform = Transform3D(0.991894, -0.0537, 0.11516, 0, 0.906308, 0.422618, -0.127065, -0.419193, 0.898962, 1.11827, 4.27401, 11.3775)
+transform = Transform3D(0.991894, -0.0536998, 0.11516, 0, 0.906308, 0.422618, -0.127065, -0.419193, 0.898962, 1.11827, 4.27401, 11.3775)
 script = ExtResource("1_tdg64")
 IsRotating = false
 
@@ -181,6 +184,9 @@ transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 1.0395
 [node name="CustomRopePosition" type="Node3D" parent="RopeDemos/MovingRopes/MovingCylinder"]
 transform = Transform3D(1, 0, 0, 0, 1, 7.35137e-08, 0, -7.35137e-08, 1, 0, -1.42, 0.425)
 
+[node name="CustomRopePosition2" type="Node3D" parent="RopeDemos/MovingRopes/MovingCylinder"]
+transform = Transform3D(1, 0, 0, 0, 1, 7.35137e-08, 0, -7.35137e-08, 1, 0, 1.43101, 0.425)
+
 [node name="VerletRopeStatic" type="Node3D" parent="RopeDemos/MovingRopes"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.35236, 3.68133, 5.42262)
 script = ExtResource("2_lows4")
@@ -194,6 +200,30 @@ DynamicCollisionMask = 2
 RopeLength = 5.0
 MaterialOverride = SubResource("StandardMaterial3D_ykvhj")
 metadata/VerletRopeObject = true
+
+[node name="MovingBox" parent="RopeDemos/MovingRopes" instance=ExtResource("7_tdg64")]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 1.03633, 0.359585, 6.75175)
+
+[node name="CustomConnection" type="Node3D" parent="RopeDemos/MovingRopes/MovingBox"]
+transform = Transform3D(1, 0, -5.32907e-15, 0, 1, 7.35137e-08, 0, -7.35137e-08, 1, 0, 0, -0.2)
+
+[node name="VerletRopeJoinedBody" type="Node3D" parent="RopeDemos/MovingRopes"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.04854, 1.85273, 6.91196)
+script = ExtResource("2_lows4")
+IsDisabledWhenInvisible = false
+SimulationBehavior = 2
+RopeLength = 1.2
+MaterialOverride = SubResource("StandardMaterial3D_nk31j")
+metadata/_custom_type_script = "uid://c3oxgehluk75x"
+
+[node name="JointSimulated" type="Node" parent="RopeDemos/MovingRopes/VerletRopeJoinedBody" node_paths=PackedStringArray("VerletRope", "StartCustomLocation", "EndBody", "EndCustomLocation")]
+script = ExtResource("3_j5lb4")
+VerletRope = NodePath("..")
+StartCustomLocation = NodePath("../../MovingCylinder/CustomRopePosition2")
+EndBody = NodePath("../../MovingBox")
+EndCustomLocation = NodePath("../../MovingBox/CustomConnection")
+JointMaxDistance = 1.2
+metadata/verlet_rope_physical_create_simulated_joint = 1841116976
 
 [node name="PhysicsJointRope" type="Node3D" parent="RopeDemos"]
 transform = Transform3D(0.974421, 0, 0.22473, 0, 1, 0, -0.22473, 0, 0.974421, -0.493877, 0, 3.55581)

--- a/demo/demo.tscn
+++ b/demo/demo.tscn
@@ -57,7 +57,7 @@ albedo_color = Color(0.789868, 0.610247, 0, 1)
 
 [sub_resource type="ImmediateMesh" id="ImmediateMesh_nk31j"]
 resource_local_to_scene = true
-metadata/verlet_rope_internal_stamp = 23819586715240
+metadata/verlet_rope_internal_stamp = 30210682600754
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_1rqa4"]
 albedo_color = Color(0.582917, 0, 0.0906055, 1)


### PR DESCRIPTION
# Verlet Rope 4 | Version 2.0.1

## Changes
* Updated `VerletJointSimulated` to allow distance joint configurations when only one `RigidBody3D` is specified. Now it's possible to connect bodies to random `Node3D`-s or just to rope's start location. 
* Updated `CreateBody` method to accept `forceReset` (`true` by default) parameter which when is set to `false` allows applying changes not connected to rope creation (connected bodies & preprocess iterations) without resetting.

## Fixes
* Updated `VisibleOnScreenNotifier3D` usage to not rely on visuals as they will stop render when out of screen, now `Aabb` is generated using rope particles which is preventing unexpected rope disappears.
* Minor `README.md` typo fixes.

## Migration & Installation
> [!WARNING]
> Update doesn't include any breaking changes, except in cases where `CreateRope` was called using `MethodName.CreateRope` as now it will require explicit passing of the parameter.

Migration (from 1.x.x versions) and installation guides are available at [GitHub Wiki](https://github.com/Tshmofen/verlet-rope-4/wiki).

> [!NOTE]
> If you have any questions or issues with the updated version feel free to reach out via [Issues](https://github.com/Tshmofen/verlet-rope-4/issues). Will try my best to help :)
> <sub>Tshmofen / Timofey Ivanov</sub>
