### PR TITLE
Fix casing of Icons directory in default values

### DIFF
--- a/addons/verlet_rope_4/Physics/Joints/DistanceForceJoint.cs
+++ b/addons/verlet_rope_4/Physics/Joints/DistanceForceJoint.cs
@@ -6,7 +6,7 @@ namespace VerletRope4.Physics.Joints;
 public partial class DistanceForceJoint : Node, IVerletExported
 {
     public static string ScriptPath => "res://addons/verlet_rope_4/Physics/Joints/DistanceForceJoint.cs";
-    public static string IconPath => "res://addons/verlet_rope_4/icons/icon_joint.svg";
+    public static string IconPath => "res://addons/verlet_rope_4/Icons/icon_joint.svg";
     public static string ExportedBase => nameof(Node);
     public static string ExportedType => nameof(DistanceForceJoint);
 

--- a/addons/verlet_rope_4/Physics/Joints/VerletJointRigid.cs
+++ b/addons/verlet_rope_4/Physics/Joints/VerletJointRigid.cs
@@ -6,7 +6,7 @@ namespace VerletRope4.Physics.Joints;
 public partial class VerletJointRigid : BaseVerletJoint, IVerletExported
 {
     public static string ScriptPath => "res://addons/verlet_rope_4/Physics/Joints/VerletJointRigid.cs";
-    public static string IconPath => "res://addons/verlet_rope_4/icons/icon_joint.svg";
+    public static string IconPath => "res://addons/verlet_rope_4/Icons/icon_joint.svg";
     public static string ExportedBase => nameof(Node);
     public static string ExportedType => nameof(VerletJointRigid);
 

--- a/addons/verlet_rope_4/Physics/Joints/VerletJointSimulated.cs
+++ b/addons/verlet_rope_4/Physics/Joints/VerletJointSimulated.cs
@@ -9,7 +9,7 @@ namespace VerletRope4.Physics.Joints;
 public partial class VerletJointSimulated : BaseVerletJoint, IVerletExported
 {
     public static string ScriptPath => "res://addons/verlet_rope_4/Physics/Joints/VerletJointSimulated.cs";
-    public static string IconPath => "res://addons/verlet_rope_4/icons/icon_joint.svg";
+    public static string IconPath => "res://addons/verlet_rope_4/Icons/icon_joint.svg";
     public static string ExportedBase => nameof(Node);
     public static string ExportedType => nameof(VerletJointSimulated);
 

--- a/addons/verlet_rope_4/Physics/VerletRopeRigid.cs
+++ b/addons/verlet_rope_4/Physics/VerletRopeRigid.cs
@@ -11,7 +11,7 @@ namespace VerletRope4.Physics;
 public partial class VerletRopeRigid : BaseVerletRopePhysical, IVerletExported
 {
     public static string ScriptPath => "res://addons/verlet_rope_4/Physics/VerletRopeRigid.cs";
-    public static string IconPath => "res://addons/verlet_rope_4/icons/icon_rope.svg";
+    public static string IconPath => "res://addons/verlet_rope_4/Icons/icon_rope.svg";
     public static string ExportedBase => nameof(Node3D);
     public static string ExportedType => nameof(VerletRopeRigid);
 

--- a/addons/verlet_rope_4/Physics/VerletRopeSimulated.cs
+++ b/addons/verlet_rope_4/Physics/VerletRopeSimulated.cs
@@ -13,7 +13,7 @@ namespace VerletRope4.Physics;
 public partial class VerletRopeSimulated : BaseVerletRopePhysical, IVerletExported
 {
     public static string ScriptPath => "res://addons/verlet_rope_4/Physics/VerletRopeSimulated.cs";
-    public static string IconPath => "res://addons/verlet_rope_4/icons/icon_rope.svg";
+    public static string IconPath => "res://addons/verlet_rope_4/Icons/icon_rope.svg";
     public static string ExportedBase => nameof(Node3D);
     public static string ExportedType => nameof(VerletRopeSimulated);
 

--- a/addons/verlet_rope_4/Rendering/VerletRopeMesh.cs
+++ b/addons/verlet_rope_4/Rendering/VerletRopeMesh.cs
@@ -8,7 +8,7 @@ namespace VerletRope4.Rendering;
 public partial class VerletRopeMesh : MeshInstance3D, IVerletExported
 {
     public static string ScriptPath => "res://addons/verlet_rope_4/Rendering/VerletRopeMesh.cs";
-    public static string IconPath => "res://addons/verlet_rope_4/icons/icon_rope_mesh.svg";
+    public static string IconPath => "res://addons/verlet_rope_4/Icons/icon_rope_mesh.svg";
     public static string ExportedBase => nameof(MeshInstance3D);
     public static string ExportedType => nameof(VerletRopeMesh);
 


### PR DESCRIPTION
The default values for IconPath is set to point to the directory "icons" with lowercase I. The folder in the project is named "Icons"

On windows this is probably fine, but on my Linux machine I had issues loading the icons due to the case sensitive file system. This fixes all the default paths to point to the right directory. 